### PR TITLE
Upgrade angular-playground from 3.4.0 to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "e2e": "protractor ./protractor.conf.js",
     "playground": "concurrently \"npm run playground:run\" \"npm run playground:serve\"",
     "playground:run": "angular-playground --no-serve",
-    "playground:serve": "webpack-dev-server --port=4201",
+    "playground:serve": "webpack-dev-server --port=4201 --config webpack.playground.config.js",
     "pree2e": "webdriver-manager update --standalone false --gecko false --quiet"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "uglifyjs-webpack-plugin": "^1.1.8",
     "url-loader": "^0.6.2",
     "webpack": "~3.11.0",
-    "webpack-dev-server": "~2.11.0"
+    "webpack-dev-server": "~2.11.0",
+    "webpack-merge": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/jasmine": "~2.8.3",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
-    "angular-playground": "^3.4.0",
+    "angular-playground": "^4.0.0",
     "autoprefixer": "^7.2.3",
     "circular-dependency-plugin": "^4.2.1",
     "codelyzer": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "autoprefixer": "^7.2.3",
     "circular-dependency-plugin": "^4.2.1",
     "codelyzer": "^4.0.1",
+    "concurrently": "^3.5.1",
     "copy-webpack-plugin": "~4.4.1",
     "file-loader": "^1.1.5",
     "html-webpack-plugin": "^2.29.0",

--- a/src/main.playground.ts
+++ b/src/main.playground.ts
@@ -1,5 +1,11 @@
-import { initializePlayground, PlaygroundModule } from "angular-playground";
-import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { PlaygroundModule } from 'angular-playground';
 
-initializePlayground('app-root');
+PlaygroundModule
+  .configure({
+    selector: 'app-root',
+    overlay: false,
+    modules: []
+  });
+
 platformBrowserDynamic().bootstrapModule(PlaygroundModule);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,7 +145,7 @@ module.exports = {
   },
   "entry": {
     "main": [
-      "./src\\main.playground.ts"
+      "./src\\main.ts"
     ],
     "polyfills": [
       "./src\\polyfills.ts"

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -1,0 +1,20 @@
+var webpackMerge = require('webpack-merge');
+var webDev = require('./webpack.config');
+var mergeStrategy = {
+  customizeObject(a, b, key) {
+    if (key === 'entry') {
+      return Object.assign({}, a, b);
+    }
+
+    return undefined;
+  }
+};
+var webpackPlaygroundMerge = webpackMerge(mergeStrategy);
+
+module.exports = webpackPlaygroundMerge(webDev, {
+  "entry": {
+    "main": [
+      "./src/main.playground.ts"
+    ]
+  }
+});

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -14,7 +14,7 @@ var webpackPlaygroundMerge = webpackMerge(mergeStrategy);
 module.exports = webpackPlaygroundMerge(webDev, {
   "entry": {
     "main": [
-      "./src/main.playground.ts"
+      "./src\\main.playground.ts"
     ]
   }
 });


### PR DESCRIPTION
This PR closes #1 

## Package upgrade
 - Upgraded `angular-playground` from 3.4.0 to 4.0.0
 - Added `concurrently` as a dev dependency
 - Changed the `main.playground.ts` to use the new package

## Webpack configuration changes
 - Added `webpack-merge` as a dev dependency
 - Added a separated webpack configuration file for playground
 - Changed the entry file of `webpack.config.js` from `main.playground.ts` to `main.js`